### PR TITLE
fixed unity player build

### DIFF
--- a/RoomAliveToolkitForUnity/RoomAliveUnity/Assets/RoomAliveToolkit/Scripts/RATSceneSetup.cs
+++ b/RoomAliveToolkitForUnity/RoomAliveUnity/Assets/RoomAliveToolkit/Scripts/RATSceneSetup.cs
@@ -1,6 +1,8 @@
 ﻿using UnityEngine;
 using System.Collections;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 
 namespace RoomAliveToolkit
 {
@@ -36,8 +38,8 @@ namespace RoomAliveToolkit
 
         public void LoadDefault3DModels()
         {
-            kinectModel = AssetDatabase.LoadAssetAtPath<GameObject>("Assets/RoomAliveToolkit/Models/Kinect.obj");
-            projectorModel = AssetDatabase.LoadAssetAtPath<GameObject>("Assets/RoomAliveToolkit/Models/Projector.obj");
+            kinectModel = Instantiate(Resources.Load("Assets/RoomAliveToolkit/Models/Kinect.obj", typeof(GameObject))) as GameObject;
+            projectorModel = Instantiate(Resources.Load("Assets/RoomAliveToolkit/Models/Projector.obj", typeof(GameObject))) as GameObject;
         }
 
         public void BuildSceneComponents()

--- a/RoomAliveToolkitForUnity/RoomAliveUnity/Assets/RoomAliveToolkit/Scripts/Utilities/UnityUtilities.cs
+++ b/RoomAliveToolkitForUnity/RoomAliveUnity/Assets/RoomAliveToolkit/Scripts/Utilities/UnityUtilities.cs
@@ -1,6 +1,5 @@
 ﻿using UnityEngine;
 using System;
-
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
@@ -78,9 +77,9 @@ namespace RoomAliveToolkit
     {
 
     }
-    [CustomPropertyDrawer(typeof(ReadOnlyAttribute))]
 
 #if UNITY_EDITOR
+    [CustomPropertyDrawer(typeof(ReadOnlyAttribute))]
     public class ReadOnlyDrawer : PropertyDrawer
     {
         public override float GetPropertyHeight(SerializedProperty property,


### PR DESCRIPTION
RATSceneSetup is now using Resources.Load instead of
AssetDatabase.LoadAssetAtPath as it was only visible in Editor mode.

Fixed the #if UNITY_EDITOR for CustomPropertyDrawer

tested on Unity 5.5.0f3 and 5.6.0f3